### PR TITLE
Refactor/products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+  - `@inline` annotations have been provided for all products.
+
 ## [0.1.0] - 2024-05-17
 
 Initial release of CliffordNumbers.jl

--- a/docs/src/api/math.md
+++ b/docs/src/api/math.md
@@ -35,12 +35,12 @@ Base.muladd(x::BaseNumber, y::T, z::T) where T<:AbstractCliffordNumber
 ### Geometric products
 
 ```@docs
-Base.:*(::AbstractCliffordNumber, ::AbstractCliffordNumber)
+Base.:*
 CliffordNumbers.:⨼
 CliffordNumbers.:⨽
 CliffordNumbers.dot
 CliffordNumbers.hestenes_dot
-CliffordNumbers.:∧(x::AbstractCliffordNumber, y::AbstractCliffordNumber)
+CliffordNumbers.:∧
 CliffordNumbers.:×
 CliffordNumbers.:⨰
 ```

--- a/src/math.jl
+++ b/src/math.jl
@@ -295,6 +295,48 @@ const wedge = ∧
 const left_contraction = ⨼
 const right_contraction = ⨽
 
+#---Commutator and anticommutator products---------------------------------------------------------#
+"""
+    ×(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q})
+    commutator(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q})
+
+Calculates the commutator (or antisymmetric) product, equal to `1//2 * (x*y - y*x)`.
+
+Note that the commutator product, in general, is *not* equal to the wedge product, which may be
+invoked with the `wedge` function or the `∧` operator.
+
+# Type promotion
+
+Because of the rational `1//2` factor in the product, inputs with scalar types subtyping `Integer`
+will be promoted to `Rational` subtypes.
+"""
+function ×(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q}) where Q
+    return 1//2 * (x*y - y*x)
+end
+
+"""
+    ⨰(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q})
+    anticommutator(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q})
+
+Calculates the anticommutator (or symmetric) product, equal to `1//2 * (x*y + y*x)`.
+
+Note that the dot product, in general, is *not* equal to the anticommutator product, which may be
+invoked with `dot`. In some cases, the preferred operators might be the left and right contractions,
+which use infix operators `⨼` and `⨽` respectively.
+
+# Type promotion
+
+Because of the rational `1//2` factor in the product, inputs with scalar types subtyping `Integer`
+will be promoted to `Rational` subtypes.
+"""
+function ⨰(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q}) where Q
+    return 1//2 * (x*y + y*x)
+end
+
+# Long names for operations
+const commutator = ×
+const anticommutator = ⨰
+
 #---Scalar products--------------------------------------------------------------------------------#
 """
     scalar_product(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q})
@@ -339,48 +381,6 @@ abs(x::AbstractCliffordNumber) = hypot(Tuple(x)...)
 Normalizes `x` so that its magnitude (as calculated by `abs2(x)`) is 1.
 """
 normalize(x::AbstractCliffordNumber) = x / abs(x)
-
-#---Commutator and anticommutator products---------------------------------------------------------#
-"""
-    ×(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q})
-    commutator(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q})
-
-Calculates the commutator (or antisymmetric) product, equal to `1//2 * (x*y - y*x)`.
-
-Note that the commutator product, in general, is *not* equal to the wedge product, which may be
-invoked with the `wedge` function or the `∧` operator.
-
-# Type promotion
-
-Because of the rational `1//2` factor in the product, inputs with scalar types subtyping `Integer`
-will be promoted to `Rational` subtypes.
-"""
-function ×(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q}) where Q
-    return 1//2 * (x*y - y*x)
-end
-
-const commutator = ×
-
-"""
-    ⨰(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q})
-    anticommutator(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q})
-
-Calculates the anticommutator (or symmetric) product, equal to `1//2 * (x*y + y*x)`.
-
-Note that the dot product, in general, is *not* equal to the anticommutator product, which may be
-invoked with `dot`. In some cases, the preferred operators might be the left and right contractions,
-which use infix operators `⨼` and `⨽` respectively.
-
-# Type promotion
-
-Because of the rational `1//2` factor in the product, inputs with scalar types subtyping `Integer`
-will be promoted to `Rational` subtypes.
-"""
-function ⨰(x::AbstractCliffordNumber{Q}, y::AbstractCliffordNumber{Q}) where Q
-    return 1//2 * (x*y + y*x)
-end
-
-const anticommutator = ⨰
 
 #---Inverses and division--------------------------------------------------------------------------#
 """

--- a/src/math.jl
+++ b/src/math.jl
@@ -206,7 +206,7 @@ for op in (:*, :∧)
     @eval begin
         @inline $op(k::KVector{0,Q}, x::AbstractCliffordNumber{Q}) where Q = only(Tuple(k)) * x
         @inline $op(x::AbstractCliffordNumber{Q}, k::KVector{0,Q}) where Q = x * only(Tuple(k))
-        @inline function $op(k::KVector{0,Q}, l::AbstractCliffordNumber{0,Q}) where Q
+        @inline function $op(k::KVector{0,Q}, l::KVector{0,Q}) where Q
             return KVector{0,Q}((only(Tuple(k)) * only(Tuple(l))))
         end
     end


### PR DESCRIPTION
All products are now implemented in a single `@eval` block, and they are all given `@inline` annotations for performance.