### PR TITLE
Minimize the size of the return type when multiplying a `KVector` by a scalar or pseudoscalar `KVector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
   - `Base.float` and `Base.big` definitions for `AbstractCliffordNumber` types and instances.
 
+### Changed
+  - Geometric products involving pseudoscalars (`KVector{K,Q}` where `K === dimension(Q)`) now
+    promote to smaller types if possible.
+
 ## [0.1.1] - 2024-05-28
 
 ### Changed

--- a/src/multiply.jl
+++ b/src/multiply.jl
@@ -157,6 +157,27 @@ Without specialization on `S`, a type suitable for the geometric product is retu
     end
 end
 
+# Extra implementation for k-vectors: special handling scalar and pseudoscalar arguments
+# TODO: can we integrate this into the above function?
+@generated function product_return_type(
+    ::Type{C1},
+    ::Type{C2},
+    ::GradeFilter{<:Any}
+) where {K1,K2,Q,C1<:KVector{K1,Q},C2<:KVector{K2,Q}}
+    D = dimension(Q)
+    # Handle the scalar and pseudoscalar cases
+    if isone(nblades(C1))
+        iszero(K1) && return :(KVector{K2,Q})
+        K1 == D && return :(KVector{$D-K2,Q})
+    elseif isone(nblades(C2))
+        iszero(K2) && return :(KVector{K1,Q})
+        K2 == D && return :(KVector{$D-K1,Q})
+    end
+    # Fall back to a Z2CliffordNumber with the right parity
+    P = isodd(xor(K1, K2))
+    return :(Z2CliffordNumber{$P,Q})
+end
+
 function product_return_type(
     ::Type{<:KVector{K1,Q}},
     ::Type{<:KVector{K2,Q}},

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -77,6 +77,17 @@ end
     @test x(y) === x * y
     @test (y)(x) === y * x
     @test_throws CliffordNumbers.AlgebraMismatch x * one(CliffordNumber{STA})
+    # Check that scalar/pseudoscalar multiplications promote correctly
+    @test k1 * KVector{0,VGA(3)}(2) === KVector{1,VGA(3)}(8, 4, 0)
+    @test KVector{0,VGA(3)}(2) * k1 === KVector{1,VGA(3)}(8, 4, 0)
+    # Test kernel directly for the scalar case (this is overridden)
+    @test CliffordNumbers.mul(k1, KVector{0,VGA(3)}(2)) === KVector{1,VGA(3)}(8, 4, 0)
+    @test CliffordNumbers.mul(KVector{0,VGA(3)}(2), k1) === KVector{1,VGA(3)}(8, 4, 0)
+    @test k1 * KVector{3,VGA(3)}(2) === KVector{2,VGA(3)}(0, -4,  8)
+    @test KVector{3,VGA(3)}(2) * k1 === KVector{2,VGA(3)}(0, -4,  8)
+    # Test promotions of KVector with Z2CliffordNumber implicitly
+    @test k1 * k2 * l2 isa OddCliffordNumber{VGA(3)}
+    @test k1 * l1 * l2 isa EvenCliffordNumber{VGA(3)}
 end
 
 @testset "Scalars" begin


### PR DESCRIPTION
When performing geometric products of `KVector` with scalars or pseudoscalars that are also `KVector`, it is possible to infer a `KVector` return type instead of the `EvenCliffordNumber` or `OddCliffordNumber` that is currently inferred.