### PR TITLE
Optimize the iteration scheme in `CliffordNumbers.mul` for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
   - Geometric products involving pseudoscalars (`KVector{K,Q}` where `K === dimension(Q)`) now
     promote to smaller types if possible.
+  - `CliffordNumbers.mul` iterates through the indices of the smaller argument, which drastically
+    reduces the performance discrepancy when the multiplication arguments are reversed if SIMD
+    vectorization is utilized.
 
 ## [0.1.1] - 2024-05-28
 


### PR DESCRIPTION
There is a significant discrepancy in performance on hardware with SIMD if two differently-sized arguments are multliplied in reverse order: in general, larger first arguments result in slower runtimes because there are more loop iterations as opposed to vectorized operations. This change generates the syntax tree differently depending on argument size.

Perhaps in the future we can come up with a heuristic to optimize code generation even further. Additionally, I want to unify the cases so we don't have a lot of boilerplate code.