### PR TITLE
Update CliffordNumbers.jl to export regressive

### DIFF
--- a/src/CliffordNumbers.jl
+++ b/src/CliffordNumbers.jl
@@ -64,8 +64,8 @@ include("multiply.jl")
 # Mathematical operations defined for all AbstractCliffordNumber instances
 include("math.jl")
 export isscalar, ispseudoscalar, scalar,  scalar_product, normalize, left_contraction, 
-    right_contraction, wedge, commutator, anticommutator, versor_inverse, exppi, exptau
-export ⨼, ⨽, ∧, ×, ⨰
+    right_contraction, wedge, commutator, anticommutator, versor_inverse, exppi, exptau, regressive
+export ⨼, ⨽, ∧, ×, ⨰, ∨
 # Pretty printing
 include("show.jl")
 


### PR DESCRIPTION
Update CliffordNumbers.jl to export `regressive` product, as well as its infix operator, `∨`