### PR TITLE
Macro for defining basis vector variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - Unexported aliases `CliffordNumbers.CliffordScalar{Q,T} === KVector{0,Q,T,1}`, 
     `CliffordNumbers.CliffordVector{Q,T,L} === KVector{1,Q,T,L}`, and
     `CliffordNumbers.CliffordBivector{Q,T,L} === KVector{2,Q,T,L}`.
+  - `@basis_vars` macro that defines basis 1-blade variables for an algebra.
 
 ### Changed
   - Split up `src/math.jl` to separate files in `src/math/`.

--- a/docs/src/api/clifford.md
+++ b/docs/src/api/clifford.md
@@ -44,3 +44,8 @@ CliffordNumbers.ispseudoscalar
 CliffordNumbers.scalar
 CliffordNumbers.pseudoscalar
 ```
+
+## Defining basis variables
+```@docs
+CliffordNumbers.@basis_vars
+```

--- a/src/CliffordNumbers.jl
+++ b/src/CliffordNumbers.jl
@@ -81,5 +81,8 @@ include("math/exponential.jl")
 export exppi, exptau
 # Pretty printing
 include("show.jl")
+# Generate basis variables with a macro
+include("variables.jl")
+export @basis_vars
 
 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,0 +1,62 @@
+#---Generate basis elements for convenience--------------------------------------------------------#
+
+basis_vars_names(Q, prefix) = [Symbol(prefix, x) for x in eachindex(Q)]
+
+function basis_vars_names(Q::CGA, prefix = Metrics.blade_symbol(Q))
+    first_names = [Symbol(prefix, :_n), Symbol(prefix, :_p)]
+    return append!(first_names, [Symbol(prefix, x) for x in 1:dimension(Q) - 2])
+end
+
+function basis_vars_expr(
+    ::Val{Q},
+    ::Type{T} = Int,
+    prefix = Metrics.blade_symbol(Q)
+) where {Q,T<:BaseNumber}
+    vars = basis_vars_names(Q, prefix)
+    exs = map(enumerate(vars)) do (n,var)
+        k = KVector{1,Q,T}(ntuple(i -> i == n, Val(dimension(Q))))
+        return :($var = $k)
+    end
+    printed = :(@info "Defined basis vectors: " *  join($vars, ", "))
+    return Expr(:block, exs..., printed)
+end
+
+"""
+    @basis_vars(Q, ::Type{T}; prefix = Metrics.blade_symbol(Q))
+
+Generates variables in the global scope representing the 1-blade basis elements of `Q`.
+
+!!! warning
+    The default prefix for most algebras is 'e', which can cause problems with multiplying through
+    juxtaposition: Julia interprets `2e0` as scientific notation. For the sake of clarity, use
+    explicit multiplication (`2*e0`) or change the prefix.
+    
+    Lorentzian geometric algebras default to `γ` as the default prefix and do not have this problem.
+
+# Examples
+```julia-repl
+julia> @basis_vars(VGA(3), prefix = :σ)
+
+```
+"""
+macro basis_vars(Q, T, prefix)
+    _Q = __module__.eval(Q)
+    _T = __module__.eval(T)
+    _prefix = __module__.eval(prefix)
+    ex = basis_vars_expr(Val(_Q), _T, _prefix)
+    return esc(:($ex))
+end
+
+macro basis_vars(Q, T)
+    _Q = __module__.eval(Q)
+    _T = __module__.eval(T)
+    ex = basis_vars_expr(Val(_Q), _T)
+    return esc(:($ex))
+end
+
+macro basis_vars(Q)
+    _Q = __module__.eval(Q)
+    ex = basis_vars_expr(Val(_Q))
+    return esc(:($ex))
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,19 +4,9 @@ using Aqua, Test
 Aqua.test_all(CliffordNumbers; unbound_args = false)
 
 # Define basis vectors for important algebras
-const σ1 = KVector{1,VGA(3)}(1, 0, 0)
-const σ2 = KVector{1,VGA(3)}(0, 1, 0)
-const σ3 = KVector{1,VGA(3)}(0, 0, 1)
-
-const e0 = KVector{1,PGA(3)}(1, 0, 0, 0)
-const e1 = KVector{1,PGA(3)}(0, 1, 0, 0)
-const e2 = KVector{1,PGA(3)}(0, 0, 1, 0)
-const e3 = KVector{1,PGA(3)}(0, 0, 0, 1)
-
-const γ0 = KVector{1,STA}(1, 0, 0, 0)
-const γ1 = KVector{1,STA}(0, 1, 0, 0)
-const γ2 = KVector{1,STA}(0, 0, 1, 0)
-const γ3 = KVector{1,STA}(0, 0, 0, 1)
+@basis_vars(VGA(3), Int, 'σ')
+@basis_vars(PGA(3), Int)
+@basis_vars(STA)
 
 @testset "CliffordNumbers.jl" begin
     include("internals.jl")


### PR DESCRIPTION
This macro, `@basis_vars(Q, T, prefix)`, where `Q` is an algebra definition, `T<:Union{Real,Complex}` is a numeric type, and `prefix` is a character or string representing the basis vector symbol, allows for the quick definition of basis 1-blades in the global scope.

The last two arguments are optional: `T` defaults to `Int` and `prefix` defaults to `Metrics.blade_symbol(Q)`, which defaults to `'e'` for vanilla/projective/conformal GAs and `γ` for Lorentzian GAs.