### PR TITLE
Fix docstrings in 1.11

### DIFF
--- a/docs/src/api/math.md
+++ b/docs/src/api/math.md
@@ -4,6 +4,7 @@
 
 ```@docs; canonical=false
 Base.reverse(::BitIndex)
+Base.adjoint(::BitIndex)
 CliffordNumbers.grade_involution(::BitIndex)
 Base.conj(::BitIndex)
 CliffordNumbers.left_complement(::BitIndex)

--- a/src/bitindex.jl
+++ b/src/bitindex.jl
@@ -169,16 +169,22 @@ pseudoscalar_index(x::AbstractCliffordNumber) = pseudoscalar_index(typeof(x))
 
 #---Grade dependent sign inversion-----------------------------------------------------------------#
 """
-    adjoint(i::BitIndex) = reverse(i::BitIndex) = i' -> BitIndex
-    adjoint(x::AbstractCliffordNumber) = reverse(x::AbstractCliffordNumber) = x' -> typeof(x)
+    reverse(i::BitIndex) = i' -> BitIndex
+    reverse(x::AbstractCliffordNumber) = x' -> typeof(x)
 
 Performs the reverse operation on the basis blade indexed by `b` or the Clifford number `x`. The 
 sign of the reverse depends on the grade of the basis blade `g`, and is positive for `g % 4 in 0:1`
 and negative for `g % 4 in 2:3`.
 """
-adjoint(i::BitIndex) = typeof(i)(xor(signbit(i), !iszero(grade(i) & 2)), UInt(i))
-reverse(i::BitIndex) = adjoint(i)
-@doc (@doc adjoint(::BitIndex)) reverse(::BitIndex)
+reverse(i::BitIndex) = typeof(i)(xor(signbit(i), !iszero(grade(i) & 2)), UInt(i))
+
+"""
+    adjoint(i::BitIndex) = i' -> BitIndex
+    adjoint(x::AbstractCliffordNumber) = x' -> typeof(x)
+
+An alias for [`reverse(i::BitIndex)`](@ref) used to implement operator notation.
+"""
+adjoint(i::BitIndex) = reverse(i)
 
 """
     grade_involution(i::BitIndex) -> BitIndex

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -185,7 +185,6 @@ const VGA2D = VGA(2)
 
 """
     VGA3D (alias for VGA(3))
-    const APS = VGA3D
 
 The algebra of physical space, a 3D VGA which is commonly used (explicitly and implicitly) to model
 non-relativistic physics. It also serves as the subalgebra of both signature conventions of the
@@ -194,8 +193,15 @@ spacetime algebra (available as [`STAEast`](@ref) and [`STAWest`](@ref)).
 The even subalgebra of this algebra is isomorphic to ℍ, the quaternions.
 """
 const VGA3D = VGA(3)
+
+"""
+    CliffordNumbers.Metrics.APS
+
+An alias for `VGA(3)` or [`VGA3D`](@ref), referring to the algebra of physical space.
+
+In the future, this may refer to a different object from the values it currently aliases.
+"""
 const APS = VGA3D
-@doc (@doc VGA3D) APS
 
 """
     PGA <: Metrics.AbstractSignature
@@ -328,7 +334,6 @@ const STAEast = LGAEast(3)
 
 """
     STAWest (alias for LGAWest(3))
-    const STA = STAWest
 
 The spacetime algebra using the West Coast sign convention (spatial dimensions square negative,
 temporal dimensions square positive), with the temporal dimension at index 0.
@@ -338,6 +343,13 @@ This convention is the default STA convention in this package, since the signatu
 [the 2D conformal geometric algebra](@ref CGA2D).
 """
 const STAWest = LGAWest(3)
+
+"""
+    STA
+
+An alias for [`STAWest`](@ref), referring to the spacetime algebra with the West Coast (mostly 
+negative) signature convention.
+"""
 const STA = STAWest
 @doc (@doc STAWest) STA
 
@@ -389,8 +401,14 @@ As with `STA`, the default convention for `STAP` is the West Coast metric. For a
 see [`STA`](@ref).
 """
 const STAPWest = Signature(5, 0b11100, 0b00001, -1)
+
+"""
+    STAP
+
+An alias for [`STAPWest`](@ref), referring to the projective spacetime algebra with the West Coast
+(mostly negative) signature convention.
+"""
 const STAP = STAPWest
-@doc (@doc STAPWest) STAP
 
 export dimension, blade_count, grades, is_degenerate, is_positive_definite
 export Signature, VGA, PGA, CGA, LGA, LGAEast, LGAWest, Exterior


### PR DESCRIPTION
There may be a regression in the use of `@doc` to duplicate documentation, so I'm avoiding its use.