### PR TITLE
Begin development of 0.2 series

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8'
+          - '1.9'
           - '1'
           - 'nightly'
         os:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Next]
+
+### Removed
+  - **[BREAKING]** `CliffordNumbers.normalize` is no longer exported to avoid a name conflict with
+    `LinearAlgebra.normalize`.
+
 ## [0.1.10] - 2024-11-06
 
 ### Added
@@ -130,6 +136,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial release of CliffordNumbers.jl
 
+[Next]:       https://github.com/brainandforce/CliffordNumbers.jl/tree/next
 [Unreleased]: https://github.com/brainandforce/CliffordNumbers.jl
 [0.1.10]:     https://github.com/brainandforce/CliffordNumbers.jl/releases/tag/v0.1.10
 [0.1.9]:      https://github.com/brainandforce/CliffordNumbers.jl/releases/tag/v0.1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Next]
 
+### Added
+  - Package extensions for `LinearAlgebra` and `StaticArraysCore` to add methods to
+    `LinearAlgebra.dot`, `LinearAlgebra.normalize`, `StaticArraysCore.similar_type`.
+
 ### Removed
   - **[BREAKING]** `CliffordNumbers.normalize` is no longer exported to avoid a name conflict with
     `LinearAlgebra.normalize`.
+  - **[BREAKING]** Support for Julia 1.8 due to the use of package extensions.
 
 ## [0.1.10] - 2024-11-06
 

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ CliffordNumbersUnitfulExt = "Unitful"
 [compat]
 Aqua = "0.8"
 LinearAlgebra = "1"
+StaticArrays = "1"
 StaticArraysCore = "1"
 Test = "1"
 Unitful = "1"
@@ -23,8 +24,10 @@ julia = "1.9"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Aqua", "Test", "Unitful"]
+test = ["Aqua", "LinearAlgebra", "StaticArrays", "Test", "Unitful"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,16 @@ authors = ["Brandon Flores"]
 version = "0.2.0-dev"
 
 [weakdeps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
+CliffordNumbersLinearAlgebraExt = "LinearAlgebra"
 CliffordNumbersUnitfulExt = "Unitful"
 
 [compat]
 Aqua = "0.8"
+LinearAlgebra = "1"
 Test = "1"
 Unitful = "1"
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -5,15 +5,18 @@ version = "0.2.0-dev"
 
 [weakdeps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
 CliffordNumbersLinearAlgebraExt = "LinearAlgebra"
+CliffordNumbersStaticArraysCoreExt = "StaticArraysCore"
 CliffordNumbersUnitfulExt = "Unitful"
 
 [compat]
 Aqua = "0.8"
 LinearAlgebra = "1"
+StaticArraysCore = "1"
 Test = "1"
 Unitful = "1"
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ CliffordNumbersUnitfulExt = "Unitful"
 Aqua = "0.8"
 Test = "1"
 Unitful = "1"
-julia = "1.8"
+julia = "1.9"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CliffordNumbers"
 uuid = "3998ac73-6bd4-4031-8035-f167dd3ed523"
 authors = ["Brandon Flores"]
-version = "0.1.10"
+version = "0.2.0-dev"
 
 [weakdeps]
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/ext/CliffordNumbersLinearAlgebraExt.jl
+++ b/ext/CliffordNumbersLinearAlgebraExt.jl
@@ -1,0 +1,9 @@
+module CliffordNumbersLinearAlgebraExt
+
+using CliffordNumbers
+using LinearAlgebra
+
+LinearAlgebra.dot(x::AbstractCliffordNumber, y::AbstractCliffordNumber) = CliffordNumbers.dot(x, y)
+LinearAlgebra.normalize(x::AbstractCliffordNumber) = CliffordNumbers.normalize(x)
+
+end

--- a/ext/CliffordNumbersStaticArraysCoreExt.jl
+++ b/ext/CliffordNumbersStaticArraysCoreExt.jl
@@ -1,0 +1,14 @@
+module CliffordNumbersStaticArraysCoreExt
+
+using CliffordNumbers
+using StaticArraysCore
+
+function StaticArraysCore.similar_type(::Type{C}, args...) where C<:AbstractCliffordNumber
+    return CliffordNumbers.similar_type(C, args...)
+end
+
+function StaticArraysCore.similar_type(x::AbstractCliffordNumber, args...) 
+    return CliffordNumbers.similar_type(x, args...)
+end
+
+end

--- a/src/CliffordNumbers.jl
+++ b/src/CliffordNumbers.jl
@@ -69,7 +69,7 @@ include("math/arithmetic.jl")
 include("math/duals.jl")
 # Scalar products, absolute values, scalar multiplication
 include("math/scalar.jl")
-export isscalar, scalar, ispseudoscalar, scalar_product, normalize
+export isscalar, scalar, ispseudoscalar, scalar_product
 # Definitions of operators for products
 include("math/products.jl")
 export left_contraction, right_contraction, wedge, regressive, commutator, anticommutator

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -117,6 +117,16 @@ form must be wrapped in a `Val` to preserve type stability.
 
 This function must be defined with all its arguments for each concrete type subtyping
 `AbstractCliffordNumber`.
+
+# Note on function export
+
+This function is nearly identical in semantics to `StaticArraysCore.similar_type`. However, since
+this package does not depend on `StaticArraysCore`, this function is not exported to avoid name
+conflicts whenever any package exporting `StaticArraysCore.similar_type` is loaded.
+
+If a package exports `StaticArraysCore.similar_type`, that function will have methods added which
+match the methods in this package with the same signature. This may be triggered explicitly if
+desired with a `using` or `import` directive.
 """
 function similar_type(x::AbstractCliffordNumber, T::Type{<:BaseNumber}, Q::Val)
     return similar_type(typeof(x), T, Q)

--- a/test/ext/LinearAlgebra.jl
+++ b/test/ext/LinearAlgebra.jl
@@ -1,0 +1,6 @@
+@testset "LinearAlgebra extensions" begin
+    k = KVector{1,VGA(3)}(4, 2, 0)
+    l = KVector{2,VGA(3)}(0, 6, 9)
+    @test CliffordNumbers.dot(k, l) === LinearAlgebra.dot(k, l)
+    @test CliffordNumbers.normalize(k) === LinearAlgebra.normalize(k)
+end

--- a/test/ext/StaticArraysCore.jl
+++ b/test/ext/StaticArraysCore.jl
@@ -1,0 +1,4 @@
+@testset "StaticArraysCore extension" begin
+    k = KVector{1,VGA(3)}(4, 2, 0)
+    @test CliffordNumbers.similar_type(k, Float32) === StaticArrays.similar_type(k, Float32)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using CliffordNumbers
-using Aqua, Test, Unitful
+using Aqua, Test
+using LinearAlgebra, StaticArrays, Unitful
 
 Aqua.test_all(CliffordNumbers; unbound_args = false)
 
@@ -15,7 +16,7 @@ Aqua.test_all(CliffordNumbers; unbound_args = false)
     include("indexing.jl")
     include("conversion.jl")
     include("operations.jl")
-    if VERSION >= v"1.9.0"
-        include("ext/Unitful.jl")
-    end
+    include("ext/LinearAlgebra.jl")
+    include("ext/StaticArraysCore.jl")
+    include("ext/Unitful.jl")
 end


### PR DESCRIPTION
I've started with including package extensions for LinearAlgebra and StaticArraysCore, and leaving `CliffordNumbers.normalize` unexported due to a conflict with `LinearAlgebra.normalize` (the package extension makes it available again).

As of now, the major breaking changes are intended to be:
  - Dropping support of Julia 1.8 due to the use of package extensions
  - Renaming of `BitIndex` to `BladeIndex` and `BitIndices` to `BladeIndices`
  - Removing the `TransformedBitIndices` type (it may be replaced with a new type at some point)

While this will not make it to the 0.2.0 release, these changes will likely be made in the near future:
  - Spinning off the Hamming number tools into a separate package
  - More convenient indexing that doesn't require `BladeIndex` arguments
  - Integrating extensions for compatibility with other packages:
      - [ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl)
      - [GeometryTypes.jl](https://github.com/JuliaGeometry/GeometryTypes.jl)
      - [Quaternions.jl](https://github.com/JuliaGeometry/Quaternions.jl)
      - [Rotations.jl](https://github.com/JuliaGeometry/Rotations.jl)