### PR TITLE
Attempt to fix missing codecov uploads

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,5 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
-        with:
-          files: lcov.info
+        env:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false


### PR DESCRIPTION
No idea what's going on, but it seems like the action isn't even being triggered.